### PR TITLE
Add data normalization layer and unified /markets endpoint; fix ESPN

### DIFF
--- a/backend/src/api/markets_unified.py
+++ b/backend/src/api/markets_unified.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, HTTPException
+
+from ..services.espn import fetch_games_next_24h
+from ..services.kalshi import fetch_markets_for_game as kalshi_fetch
+from ..services.polymarket import fetch_market_for_game as polymarket_fetch
+from ..services.normalize import normalize_game
+
+router = APIRouter(tags=["markets"])
+
+
+@router.get("/markets")
+def get_markets():
+    try:
+        games = fetch_games_next_24h()
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"ESPN API error: {e}")
+
+    results = []
+    for game in games:
+        try:
+            kalshi_markets = kalshi_fetch(game)
+        except Exception:
+            kalshi_markets = []
+
+        try:
+            pm_market = polymarket_fetch(game)
+        except Exception:
+            pm_market = None
+
+        results.append(normalize_game(game, kalshi_markets, pm_market))
+
+    return {"games": results, "count": len(results)}

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -3,12 +3,14 @@ from fastapi import FastAPI
 from .api.schedule import router as schedule_router
 from .api.kalshi import router as kalshi_router
 from .api.polymarket import router as polymarket_router
+from .api.markets_unified import router as markets_router
 
 app = FastAPI(title="Dynamite Gambling API")
 
 app.include_router(schedule_router)
 app.include_router(kalshi_router)
 app.include_router(polymarket_router)
+app.include_router(markets_router)
 
 @app.get("/")
 async def root():

--- a/backend/src/services/espn.py
+++ b/backend/src/services/espn.py
@@ -34,8 +34,13 @@ def fetch_games_next_24h() -> list[GameMatchup]:
     now = datetime.now(timezone.utc)
     cutoff = now + timedelta(hours=24)
 
-    # Query both today and tomorrow in case the 24h window spans midnight UTC
-    dates = {now.strftime("%Y%m%d"), cutoff.strftime("%Y%m%d")}
+    # ESPN scoreboard uses Eastern dates, not UTC. Compute dates in EDT (UTC-4)
+    # so late-night games (e.g. 9:30 PM EDT = 1:30 AM UTC next day) are found.
+    eastern = timezone(timedelta(hours=-4))
+    dates = {
+        now.astimezone(eastern).strftime("%Y%m%d"),
+        cutoff.astimezone(eastern).strftime("%Y%m%d"),
+    }
 
     games: list[GameMatchup] = []
     with httpx.Client(timeout=10.0) as client:

--- a/backend/src/services/normalize.py
+++ b/backend/src/services/normalize.py
@@ -1,0 +1,74 @@
+from typing import TypedDict
+
+from .espn import GameMatchup
+from .kalshi import KalshiMarket
+from .polymarket import PolymarketMarket
+
+
+class PlatformOdds(TypedDict):
+    kalshi: float | None      # win probability 0.0–1.0, None if no market
+    polymarket: float | None
+
+
+class TeamOdds(TypedDict):
+    name: str   # e.g. "Celtics"
+    abbr: str   # e.g. "BOS"
+    odds: PlatformOdds
+
+
+class NormalizedGame(TypedDict):
+    game_id: str
+    game_time: str  # ISO 8601 UTC
+    home: TeamOdds
+    away: TeamOdds
+
+
+def _kalshi_midpoint(market: KalshiMarket) -> float:
+    return (float(market["yes_bid"]) + float(market["yes_ask"])) / 2
+
+
+def _polymarket_price(pm_market: PolymarketMarket, keyword: str) -> float | None:
+    for outcome, price in zip(pm_market["outcomes"], pm_market["prices"]):
+        if outcome.lower() == keyword.lower():
+            return float(price)
+    return None
+
+
+def normalize_game(
+    matchup: GameMatchup,
+    kalshi_markets: list[KalshiMarket],
+    pm_market: PolymarketMarket | None,
+) -> NormalizedGame:
+    home_abbr = matchup["home_abbr"]
+    away_abbr = matchup["away_abbr"]
+    home_keyword = matchup["home_kalshi_keyword"]
+    away_keyword = matchup["away_kalshi_keyword"]
+
+    # Match Kalshi markets to teams by ticker suffix (e.g. KXNBAGAME-...-BOS)
+    home_kalshi = next(
+        (m for m in kalshi_markets if m["ticker"].endswith(f"-{home_abbr}")), None
+    )
+    away_kalshi = next(
+        (m for m in kalshi_markets if m["ticker"].endswith(f"-{away_abbr}")), None
+    )
+
+    return NormalizedGame(
+        game_id=matchup["game_id"],
+        game_time=matchup["game_time"],
+        home=TeamOdds(
+            name=home_keyword,
+            abbr=home_abbr,
+            odds=PlatformOdds(
+                kalshi=_kalshi_midpoint(home_kalshi) if home_kalshi else None,
+                polymarket=_polymarket_price(pm_market, home_keyword) if pm_market else None,
+            ),
+        ),
+        away=TeamOdds(
+            name=away_keyword,
+            abbr=away_abbr,
+            odds=PlatformOdds(
+                kalshi=_kalshi_midpoint(away_kalshi) if away_kalshi else None,
+                polymarket=_polymarket_price(pm_market, away_keyword) if pm_market else None,
+            ),
+        ),
+    )


### PR DESCRIPTION
Eastern date bug

- services/normalize.py — normalizes Kalshi (bid/ask, 2 markets/game) and Polymarket (single price, 1 market/game) into a common NormalizedGame schema with win probabilities for each team from both platforms
- api/markets_unified.py — GET /markets chains ESPN → Kalshi + Polymarket → normalization; returns partial data if one platform has no market for a game
- services/espn.py — fix date query to use Eastern time (UTC-4) instead of UTC so late-night games (e.g. 9:30 PM EDT = 1:30 AM UTC) aren't dropped after midnight