### PR TITLE
Add auth routes and fix backend dependencies Resolves #40

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,6 @@
 
 # PostgreSQL connection string
 DATABASE_URL=postgresql://user:password@localhost:5432/dynamite
+
+# Secret key for JWT signing - use long random string in actual use
+JWT_SECRET=change-to-a-long-random-secret

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,9 @@ fastapi==0.109.2
 uvicorn==0.27.1
 redis==5.0.1
 httpx==0.27.0
+sqlalchemy==2.0.28
+psycopg2-binary==2.9.9
+python-dotenv==1.0.1
+passlib[bcrypt]==1.7.4
+python-jose[cryptography]==3.3.0
+apscheduler==3.10.4

--- a/backend/src/api/auth.py
+++ b/backend/src/api/auth.py
@@ -1,0 +1,42 @@
+import os
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from jose import jwt
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+from ..db.connection import get_db
+from ..db.models import User
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+SECRET_KEY = os.getenv("JWT_SECRET", "change-me-in-production")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+class LoginRequest(BaseModel):
+    username: str  # frontend sends "username"; we look it up as email in the DB
+    password: str
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+def create_access_token(user_id: str) -> str:
+    expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    return jwt.encode({"sub": user_id, "exp": expire}, SECRET_KEY, algorithm=ALGORITHM)
+
+@router.post("/login", response_model=TokenResponse)
+def login(body: LoginRequest, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email == body.username).first()
+    if not user or not pwd_context.verify(body.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials.",
+        )
+    token = create_access_token(str(user.id))
+    return TokenResponse(access_token=token)

--- a/backend/src/db/connection.py
+++ b/backend/src/db/connection.py
@@ -1,4 +1,5 @@
 import os
+from fastapi import HTTPException, status
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 from dotenv import load_dotenv
@@ -7,10 +8,19 @@ load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 
-engine = create_engine(DATABASE_URL)
-SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+if DATABASE_URL:
+    engine = create_engine(DATABASE_URL)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+else:
+    engine = None
+    SessionLocal = None
 
 def get_db():
+    if SessionLocal is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Database not configured — add DATABASE_URL to backend/.env",
+        )
     db = SessionLocal()
     try:
         yield db
@@ -26,9 +36,9 @@ def test_connection():
     try:
         with engine.connect() as conn:
             conn.execute(text("SELECT 1"))
-        print("✅ Connection successful!")
+        print("Connection successful")
     except Exception as e:
-        print(f"❌ Failed: {e}")
+        print(f"Failed with error: {e}")
 
 if __name__ == "__main__":
     test_connection()

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -5,6 +5,7 @@ from .api.schedule import router as schedule_router
 from .api.kalshi import router as kalshi_router
 from .api.polymarket import router as polymarket_router
 from .api.markets_unified import router as markets_router
+from .api.auth import router as auth_router
 
 app = FastAPI(title="Dynamite Gambling API")
 
@@ -19,6 +20,7 @@ app.include_router(schedule_router)
 app.include_router(kalshi_router)
 app.include_router(polymarket_router)
 app.include_router(markets_router)
+app.include_router(auth_router)
 
 @app.get("/")
 async def root():

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -6,13 +6,14 @@ from .api.kalshi import router as kalshi_router
 from .api.polymarket import router as polymarket_router
 from .api.markets_unified import router as markets_router
 from .api.auth import router as auth_router
+from .api.bets import router as bets_router
 
 app = FastAPI(title="Dynamite Gambling API")
 
 app.add_middleware(
     CORSMiddleware,
     allow_origin_regex=r"http://localhost:\d+",
-    allow_methods=["GET"],
+    allow_methods=["GET", "POST"],
     allow_headers=["*"],
 )
 
@@ -21,10 +22,13 @@ app.include_router(kalshi_router)
 app.include_router(polymarket_router)
 app.include_router(markets_router)
 app.include_router(auth_router)
+app.include_router(bets_router)
+
 
 @app.get("/")
 async def root():
     return {"message": "Welcome to the Dynamite Gambling API"}
+
 
 @app.get("/health")
 async def health_check():


### PR DESCRIPTION
- Add POST /auth/login returning JWT bearer token
- Fix requirements.txt: add sqlalchemy, psycopg2-binary, python-dotenv, passlib, python-jose, apscheduler
- Fix connection.py crash when DATABASE_URL is not set (returns 503 instead)
- Update CORS to allow POST methods for auth and future bet routes