### PR TITLE
Add POST /bets and GET /users/me, wire frontend bet logging to backend resolves #42

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv/
+venv/
 __pycache__/
 *.pyc
 .env

--- a/backend/src/api/bets.py
+++ b/backend/src/api/bets.py
@@ -1,0 +1,145 @@
+import os
+from datetime import datetime, date, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from jose import jwt, JWTError
+from pydantic import BaseModel
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from ..db.connection import get_db
+from ..db.models import User, Market, PlacedBet
+
+router = APIRouter(tags=["bets"])
+
+SECRET_KEY = os.getenv("JWT_SECRET", "change-me-in-production")
+ALGORITHM = "HS256"
+
+_bearer = HTTPBearer()
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer),
+    db: Session = Depends(get_db),
+) -> User:
+    token = credentials.credentials
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id: str | None = payload.get("sub")
+        if not user_id:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token.")
+    except JWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token.")
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found.")
+    return user
+
+
+def _today_start() -> datetime:
+    today = date.today()
+    return datetime(today.year, today.month, today.day, tzinfo=timezone.utc)
+
+
+@router.get("/users/me")
+def get_me(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    today = _today_start()
+    bets_today = (
+        db.query(PlacedBet)
+        .filter(PlacedBet.user_id == current_user.id, PlacedBet.placed_at >= today)
+        .count()
+    )
+    amount_today = (
+        db.query(func.sum(PlacedBet.amount))
+        .filter(PlacedBet.user_id == current_user.id, PlacedBet.placed_at >= today)
+        .scalar()
+        or 0
+    )
+    return {
+        "username": current_user.email,
+        "max_bets_per_day": current_user.max_bets_per_day,
+        "max_daily_spend": float(current_user.max_daily_spend),
+        "bets_today": bets_today,
+        "amount_today": float(amount_today),
+    }
+
+
+class PlaceBetRequest(BaseModel):
+    game_id: str
+    event_name: str
+    platform: str
+    team: str
+    team_name: str
+    amount: float
+    price_at_entry: Optional[float] = None
+
+
+@router.post("/bets", status_code=201)
+def place_bet(
+    body: PlaceBetRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    today = _today_start()
+
+    bets_today = (
+        db.query(PlacedBet)
+        .filter(PlacedBet.user_id == current_user.id, PlacedBet.placed_at >= today)
+        .count()
+    )
+    if bets_today >= current_user.max_bets_per_day:
+        raise HTTPException(status_code=400, detail="daily_bet_limit")
+
+    amount_today = (
+        db.query(func.sum(PlacedBet.amount))
+        .filter(PlacedBet.user_id == current_user.id, PlacedBet.placed_at >= today)
+        .scalar()
+        or 0
+    )
+    if float(amount_today) + body.amount > float(current_user.max_daily_spend):
+        raise HTTPException(status_code=400, detail="daily_amount_limit")
+
+    # Look up or create a Market row (Kevin's scheduler will upsert the real one later;
+    # this ensures the FK constraint is satisfied immediately when a user logs a bet)
+    market = db.query(Market).filter(
+        Market.external_id == body.game_id,
+        Market.platform == body.platform,
+    ).first()
+    if not market:
+        market = Market(
+            external_id=body.game_id,
+            platform=body.platform,
+            title=body.event_name,
+            category="NBA",
+        )
+        db.add(market)
+        db.flush()
+
+    bet = PlacedBet(
+        user_id=current_user.id,
+        market_id=market.id,
+        platform=body.platform,
+        amount=body.amount,
+        status="active",
+    )
+    db.add(bet)
+    db.commit()
+    db.refresh(bet)
+
+    return {
+        "id": str(bet.id),
+        "game_id": body.game_id,
+        "event_name": body.event_name,
+        "platform": body.platform,
+        "team": body.team,
+        "team_name": body.team_name,
+        "amount": body.amount,
+        "price_at_entry": body.price_at_entry,
+        "status": bet.status,
+        "placed_at": bet.placed_at.isoformat() if bet.placed_at else None,
+    }

--- a/frontend/src/api/bets.js
+++ b/frontend/src/api/bets.js
@@ -1,14 +1,13 @@
-// localStorage-based bet storage used until backend auth and DB wiring are complete.
-// Daily limits (max 5 bets, $50) reset automatically at midnight local time —
-// getLimits() compares the stored date string against today's and returns fresh
-// zeros if they don't match, so no scheduled job is needed.
-//
-// localStorage keys:
-//   dg_bets   — JSON array of all placed bets
-//   dg_limits — today's running totals + the date they belong to
+// Bet logging. When a real JWT is present, calls POST /bets on the backend
+// and mirrors the result into localStorage so getBets() works offline too.
+// Falls back to localStorage-only when the backend is unreachable or the user
+// is not logged in (mock-token from offline login also falls through).
+
+import { getToken } from "./auth";
 
 const BETS_KEY = "dg_bets";
 const LIMITS_KEY = "dg_limits";
+const API_BASE = "http://localhost:8000";
 
 const DEFAULT_LIMITS = { max_bets_per_day: 5, max_daily_amount: 50.0 };
 
@@ -36,7 +35,48 @@ export function getLimits() {
   }
 }
 
-export function addBet({ game_id, event_name, platform, team, team_name, amount, price_at_entry }) {
+export async function addBet({ game_id, event_name, platform, team, team_name, amount, price_at_entry }) {
+  const token = getToken();
+
+  if (token && token !== "mock-token") {
+    try {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), 3000);
+      const res = await fetch(`${API_BASE}/bets`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ game_id, event_name, platform, team, team_name, amount, price_at_entry }),
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        if (data.detail === "daily_bet_limit") return { ok: false, reason: "daily_bet_limit" };
+        if (data.detail === "daily_amount_limit") return { ok: false, reason: "daily_amount_limit" };
+        return { ok: false, reason: data.detail ?? "error" };
+      }
+      const bet = await res.json();
+      // Mirror into localStorage so getBets() reflects it immediately
+      const bets = getBets();
+      bets.push(bet);
+      localStorage.setItem(BETS_KEY, JSON.stringify(bets));
+      const limits = getLimits();
+      const updated = {
+        ...limits,
+        date: todayKey(),
+        bets_today: limits.bets_today + 1,
+        amount_today: limits.amount_today + amount,
+      };
+      localStorage.setItem(LIMITS_KEY, JSON.stringify(updated));
+      return { ok: true, bet, limits: updated };
+    } catch {
+      // Backend unreachable — fall through to localStorage
+    }
+  }
+
+  // localStorage fallback (no token, mock token, or backend down)
   const limits = getLimits();
   if (limits.bets_today >= limits.max_bets_per_day) {
     return { ok: false, reason: "daily_bet_limit" };

--- a/frontend/src/components/BetModal.jsx
+++ b/frontend/src/components/BetModal.jsx
@@ -26,7 +26,7 @@ export default function BetModal({ game, limits, user, onClose, onBetLogged, onL
   const priceAtEntry = selectedTeam.odds[platform];
   const locked = isAtLimit(limits);
 
-  function handleSubmit(e) {
+  async function handleSubmit(e) {
     e.preventDefault();
     const amt = parseFloat(amount);
     if (!amt || amt <= 0) {
@@ -34,7 +34,7 @@ export default function BetModal({ game, limits, user, onClose, onBetLogged, onL
       return;
     }
 
-    const result = addBet({
+    const result = await addBet({
       game_id: game.game_id,
       event_name: `${game.away.abbr} @ ${game.home.abbr}`,
       platform,


### PR DESCRIPTION
- POST /bets: JWT-authenticated; enforces daily bet/spend limits from DB user record; persists to placed_bets table
- GET /users/me: returns user limits and today's usage for frontend limit display
- frontend/api/bets.js: addBet now async; tries backend first when real JWT present, falls back to localStorage
- BetModal: await addBet