### PR TITLE
fix: add side column to price_history and split chart by team

### DIFF
--- a/backend/src/api/markets_unified.py
+++ b/backend/src/api/markets_unified.py
@@ -61,6 +61,7 @@ def get_price_history(game_id: str, db: Session = Depends(get_db)):
         "history": [
             {
                 "platform": h.platform,
+                "side": h.side,
                 "odds": float(h.odds),
                 "recorded_at": h.recorded_at.isoformat() if h.recorded_at else None,
             }

--- a/backend/src/db/models.py
+++ b/backend/src/db/models.py
@@ -39,6 +39,7 @@ class PriceHistory(Base):
     id          = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     market_id   = Column(UUID(as_uuid=True), ForeignKey("markets.id", ondelete="CASCADE"))
     platform    = Column(String(50), nullable=False)
+    side        = Column(String(10), nullable=False)  # "home" or "away"
     odds        = Column(Numeric(6, 4), nullable=False)
     recorded_at = Column(TIMESTAMP, server_default=func.now())
 

--- a/backend/src/services/poller.py
+++ b/backend/src/services/poller.py
@@ -49,7 +49,7 @@ def poll_and_cache():
     try:
         now = datetime.now(timezone.utc)
         for normalized in results:
-            for side in [normalized["home"], normalized["away"]]:
+            for side_key, side in [("home", normalized["home"]), ("away", normalized["away"])]:
                 for platform_key in ["kalshi", "polymarket"]:
                     odds_value = side["odds"].get(platform_key)
                     if odds_value is None:
@@ -77,6 +77,7 @@ def poll_and_cache():
                     db.add(PriceHistory(
                         market_id=market.id,
                         platform=platform_key,
+                        side=side_key,
                         odds=odds_value,
                     ))
 

--- a/frontend/src/components/BetModal.jsx
+++ b/frontend/src/components/BetModal.jsx
@@ -134,10 +134,10 @@ export default function BetModal({ game, limits, user, onClose, onBetLogged, onL
 
         {/* Odds history chart */}
         <p style={{ margin: "0 0 10px", fontSize: 11, textTransform: "uppercase", letterSpacing: "0.08em", color: theme.colors.textDim, fontFamily: theme.fonts.body }}>
-          Odds History (Favorite Win %)
+          Win Probability Over Time
         </p>
         <div style={{ marginBottom: 24 }}>
-          <PriceHistoryChart gameId={game.game_id} />
+          <PriceHistoryChart gameId={game.game_id} home={game.home} away={game.away} />
         </div>
 
         {/* Log a bet / lockout */}

--- a/frontend/src/components/PriceHistoryChart.jsx
+++ b/frontend/src/components/PriceHistoryChart.jsx
@@ -5,7 +5,17 @@ import {
 import { theme } from "../theme";
 import { fetchPriceHistory } from "../api/markets";
 
-export default function PriceHistoryChart({ gameId }) {
+// Four series: each team × each platform, distinguished by color and dash style
+function seriesConfig(home, away) {
+  return [
+    { key: `kalshi_home`,      label: `Kalshi · ${home.abbr}`,      stroke: theme.colors.kalshi,      dash: "0" },
+    { key: `kalshi_away`,      label: `Kalshi · ${away.abbr}`,      stroke: theme.colors.kalshi,      dash: "4 3" },
+    { key: `polymarket_home`,  label: `Polymarket · ${home.abbr}`,  stroke: theme.colors.polymarket,  dash: "0" },
+    { key: `polymarket_away`,  label: `Polymarket · ${away.abbr}`,  stroke: theme.colors.polymarket,  dash: "4 3" },
+  ];
+}
+
+export default function PriceHistoryChart({ gameId, home, away }) {
   const [chartData, setChartData] = useState(null);
 
   useEffect(() => {
@@ -16,8 +26,8 @@ export default function PriceHistoryChart({ gameId }) {
       for (const row of history) {
         const t = row.recorded_at?.slice(11, 16) ?? "?";
         if (!byTime[t]) byTime[t] = { time: t };
-        const cur = byTime[t][row.platform];
-        byTime[t][row.platform] = cur == null ? row.odds : Math.max(cur, row.odds);
+        const key = `${row.platform}_${row.side}`;
+        byTime[t][key] = row.odds;
       }
       setChartData(
         Object.values(byTime).sort((a, b) => a.time.localeCompare(b.time))
@@ -40,8 +50,10 @@ export default function PriceHistoryChart({ gameId }) {
     );
   }
 
+  const series = seriesConfig(home, away);
+
   return (
-    <ResponsiveContainer width="100%" height={150}>
+    <ResponsiveContainer width="100%" height={180}>
       <LineChart data={chartData} margin={{ top: 4, right: 4, left: -12, bottom: 0 }}>
         <XAxis dataKey="time" tick={{ fontSize: 10, fill: theme.colors.textDim }} />
         <YAxis
@@ -51,7 +63,7 @@ export default function PriceHistoryChart({ gameId }) {
           width={36}
         />
         <Tooltip
-          formatter={(v) => `${(v * 100).toFixed(1)}%`}
+          formatter={(v, name) => [`${(v * 100).toFixed(1)}%`, name]}
           contentStyle={{
             background: theme.colors.surface,
             border: `1px solid ${theme.colors.border}`,
@@ -59,9 +71,21 @@ export default function PriceHistoryChart({ gameId }) {
             fontSize: 12,
           }}
         />
-        <Legend wrapperStyle={{ fontSize: 11, fontFamily: theme.fonts.body }} />
-        <Line type="monotone" dataKey="kalshi" stroke={theme.colors.kalshi} strokeWidth={2} dot={{ r: 3 }} activeDot={{ r: 5 }} />
-        <Line type="monotone" dataKey="polymarket" stroke={theme.colors.polymarket} strokeWidth={2} dot={{ r: 3 }} activeDot={{ r: 5 }} />
+        <Legend wrapperStyle={{ fontSize: 10, fontFamily: theme.fonts.body }} />
+        {series.map(({ key, label, stroke, dash }) => (
+          <Line
+            key={key}
+            type="monotone"
+            dataKey={key}
+            name={label}
+            stroke={stroke}
+            strokeWidth={2}
+            strokeDasharray={dash}
+            dot={{ r: 3 }}
+            activeDot={{ r: 5 }}
+            connectNulls
+          />
+        ))}
       </LineChart>
     </ResponsiveContainer>
   );


### PR DESCRIPTION
## Summary
The `price_history` table previously stored only `market_id`, `platform`, and `odds` — with no way to tell which team (home/away) each odds row belonged to. This made the price history chart effectively useless: both lines plotted the same blended values, and users could not tell whether they were looking at the home or away team's odds over time.

## Changes
- **`backend/src/db/models.py`** — added `side` column (`"home"` | `"away"`) to `PriceHistory`
- **`backend/src/services/poller.py`** — passes `side=side_key` when writing each row so home/away is always labeled
- **`backend/src/api/markets_unified.py`** — history endpoint now returns `side` in every row
- **`frontend/src/components/PriceHistoryChart.jsx`** — chart now renders 4 labeled lines (Kalshi · HOME, Kalshi · AWAY, Polymarket · HOME, Polymarket · AWAY) with solid lines for home and dashed lines for away
- **`frontend/src/components/BetModal.jsx`** — passes `home` and `away` team objects to the chart; updated label from "Odds History (Favorite Win %)" to "Win Probability Over Time"

## User Impact
Users can now actually see how each team's odds are moving on each platform over time, making it possible to:
1. Spot when one platform consistently offers better odds for a given team
2. See where arbitrage opportunities are coming from visually
3. Track price movement that may signal news (injury reports, sharp money, etc.)

## Migration Note
Anyone pulling this branch will need to drop the existing `price_history` table so SQLAlchemy can recreate it with the new column on next backend startup: docker exec -it 520proj-postgres-1 psql -U dynamite -d dynamite -c "DROP TABLE IF EXISTS price_history CASCADE;"